### PR TITLE
Update download_driver.py

### DIFF
--- a/bose/download_driver.py
+++ b/bose/download_driver.py
@@ -41,10 +41,13 @@ def move_driver():
 
 
 def download_driver():
+    build_dir = "build"
     
-    recreate_build_dir()
+    if not os.path.exists(build_dir):
+        os.makedirs(build_dir)
+
     major_version = get_major_version(get_chrome_version())
-    print(f'[INFO] Downloading Driver for Chrome Version {major_version} in build/ directory. This is a one-time process. Download in progress...')
+    print(f'[INFO] Downloading Driver for Chrome Version {major_version} in {build_dir}/ directory. This is a one-time process. Download in progress...')
 
     download_driver_in_path()
     move_driver()


### PR DESCRIPTION
chrome 115 has this issue with bose (linux) so you have to most times manually download chrome 115 drivers and when you manually provider a driver and move the folder to build bose auto removes it and goes ahead with the error, so here's a fix.